### PR TITLE
Feat/direct message

### DIFF
--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -179,43 +179,35 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     return { status: HttpStatus.OK };
   }
 
-  @SubscribeMessage('direct-message')
-  async onDirectMessage(client: Socket, dto: DirectMessageDto) {
-    this.logger.debug('Client Send Event <direct-message>');
+  @SubscribeMessage('dm-send')
+  async onDirectMessageSend(client: Socket, dto: DirectMessageDto) {
+    this.logger.debug('Client Send Event <dm-send>');
 
-    // await this.chatService.directMessage(client, dto);
-    dto.senderId = await this.clientRepository.findUserId(client.id);
-    const receiver = await this.clientRepository.findClientId(dto.receiverId);
-    client
-      .to(receiver)
-      .except('block-' + dto.senderId)
-      .emit('direct-message', dto);
-    client.emit('direct-message', dto);
-    // const viewed: boolean = await client.emitWithAck('direct-message', dto);
+    await this.chatService.directMessage(client, dto);
 
-    await this.chatService.createAndSave(dto, false);
     return { status: HttpStatus.OK };
   }
 
-  @SubscribeMessage('load-message')
-  async onMessageLoad(client: Socket, loadMessageDto: LoadMessageDto) {
-    this.logger.debug('Client Send Event <load-message>');
+  @SubscribeMessage('dm-load')
+  async onDirectMessageLoad(client: Socket, loadMessageDto: LoadMessageDto) {
+    this.logger.debug('Client Send Event <dm-load>');
     const userId = await this.clientRepository.findUserId(client.id);
     const messages = await this.chatService.loadMessage(userId, loadMessageDto);
     return { status: HttpStatus.OK, body: messages };
   }
 
-  // 없어질 함수
-  @SubscribeMessage('user-list')
-  async onUserList(client: Socket) {
-    this.logger.debug('Client Send Event <user-list>');
+  @SubscribeMessage('dm-load-unviewed')
+  async onDirectMessageLoadUnRead(
+    client: Socket,
+    loadMessageDto: LoadMessageDto,
+  ) {
+    this.logger.debug('Client Send Event <dm-load-unviewed>');
     const userId = await this.clientRepository.findUserId(client.id);
-    const connectedUsers = await this.clientRepository.connectedUserIds();
-    const ids = Array.from(connectedUsers).filter((id) => {
-      return id !== userId;
-    });
-    const users = await this.userService.getUserDataByIds(ids);
-    return { status: HttpStatus.OK, body: users };
+    const messages = await this.chatService.loadUnViewedMessage(
+      userId,
+      loadMessageDto,
+    );
+    return { status: HttpStatus.OK, body: messages };
   }
 
   @SubscribeMessage('friend-list')

--- a/src/chat/dto/view-message.dto.ts
+++ b/src/chat/dto/view-message.dto.ts
@@ -1,0 +1,5 @@
+export class ViewMessageDto {
+  targetId: number;
+  minId: number;
+  maxId: number;
+}

--- a/src/folllow/follow.service.ts
+++ b/src/folllow/follow.service.ts
@@ -142,12 +142,14 @@ export class FollowService {
       .select('follow.id')
       .addSelect('following.id')
       .addSelect('following.nickName')
+      .addSelect('following.intraName')
       .addSelect('following.avatar')
       .getMany();
 
     return friends.map((fr) => ({
       friendId: fr.following.id,
       freindNickName: fr.following.nickName,
+      freindIntraName: fr.following.intraName,
       freindProfile: fr.following.avatar,
     }));
   }

--- a/src/room/room.repository.ts
+++ b/src/room/room.repository.ts
@@ -39,4 +39,16 @@ export class RoomRepository {
   async findRoomIdByUserId(userId): Promise<string> {
     return this.cacheManager.get('room-user-' + userId);
   }
+
+  async saveMuteTimerId(targetId: number, timerId: NodeJS.Timeout) {
+    await this.cacheManager.set('timer-' + targetId, timerId);
+  }
+
+  async findMuteTimerId(targetId: number): Promise<NodeJS.Timeout> {
+    return await this.cacheManager.get('timer-' + targetId);
+  }
+
+  async deleteMuteTimerId(targetId: number) {
+    await this.cacheManager.del('timer-' + targetId);
+  }
 }

--- a/src/ws/client.repository.ts
+++ b/src/ws/client.repository.ts
@@ -46,16 +46,4 @@ export class ClientRepository {
     if (status) return status;
     return 'OFFLINE';
   }
-
-  async saveTimerId(targetId: number, timerId: NodeJS.Timeout) {
-    await this.cacheManager.set('timer-' + targetId, timerId);
-  }
-
-  async findTimerId(targetId: number): Promise<NodeJS.Timeout> {
-    return await this.cacheManager.get('timer-' + targetId);
-  }
-
-  async deleteTimerId(targetId: number) {
-    await this.cacheManager.del('timer-' + targetId);
-  }
 }

--- a/src/ws/client.service.ts
+++ b/src/ws/client.service.ts
@@ -94,4 +94,12 @@ export class ClientService {
       status: status,
     });
   }
+
+  async findUserIdByClientId(id: string): Promise<number> {
+    return await this.clientRepository.findUserId(id);
+  }
+
+  async findClientIdByUserId(id: number): Promise<string> {
+    return await this.clientRepository.findClientId(id);
+  }
 }


### PR DESCRIPTION
1. friend-list 응답에 IntraName 추가
클라이언트의 오른쪽 네비게이션 친구바에 사용될 intraName

2. ChatGateWay::onDirectMessageRead, ChatService::viewMessage
클라이언트에 저장은 되어 있지만 안 읽은 메시지를 읽었음을 알리는 이벤트 <dm-view> 추가

3. RoomService 가 ClientRepository 대신 ClientService 를 호출하도록 수정
다른 모듈의 레포 호출을 지양

4. ClientRepository::(saveMuteTimerId, findMuteTimerId, deleteMuteTimerId) 모두 RoomRepository 로 이동
client 보다는 room에 더 어울리기 때문

5. feat: ClientService::findUserIdByClientId, findClientIdByUserId

7. 안 읽은 DM을 한 번에 불러오는 이벤트<dm-load-unviewed> 추가 (다 읽음 처리)
direct-message -> dm-send
load-message -> dm-load